### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,68 +2,26 @@
 
 {{ DESCRIPTION }}
 
-## Prerequisites
-
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule/Process-PSModule) for building, testing and publishing the module.
-
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name {{ NAME }}
 Import-Module -Name {{ NAME }}
 ```
 
-## Usage
-
-Here is a list of example that are typical use cases for the module.
-
-### Example 1: Greet an entity
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Greet-Entity -Name 'World'
-Hello, World!
-```
-
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Import-Module -Name PSModuleTemplate
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
-
 ## Documentation
 
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+Documentation is published at [psmodule.io/{{ NAME }}](https://psmodule.io/{{ NAME }}/).
+
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module {{ NAME }}
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,3 @@ Use PowerShell help and command discovery for module details:
 Get-Command -Module {{ NAME }}
 Get-Help -Name CommandName -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Install-PSResource -Name {{ NAME }}
 Import-Module -Name {{ NAME }}
 ```
 
+## Capabilities
+
+Use this section to show the most important things the module makes possible. Keep it short and focused on discovery.
+
+```powershell
+# Replace this with a real example that demonstrates the module's value.
+Get-Command -Module {{ NAME }}
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/{{ NAME }}](https://psmodule.io/{{ NAME }}/).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module {{ NAME }}
-Get-Help <CommandName> -Examples
+Get-Help -Name CommandName -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Get-Command -Module {{ NAME }}
 
 ## Documentation
 
-Documentation is published at [psmodule.io/{{ NAME }}](https://psmodule.io/{{ NAME }}/).
+Documentation is published at `https://psmodule.io/{{ NAME }}/`.
 
 Use PowerShell help and command discovery for module details:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Import-Module -Name {{ NAME }}
 
 ## Capabilities
 
-Use this section to show the most important things the module makes possible. Keep it short and focused on discovery.
+Use this section to show the most important things the module makes possible. Keep it short: this is discovery and a first mental model, not the command reference.
 
 ```powershell
 # Replace this with a real example that demonstrates the module's value.


### PR DESCRIPTION
New PowerShell module repositories now start with a README that includes a concise capability showcase before the generated documentation link. This keeps README pages useful as a start page while leaving command reference details in PowerShell help and generated docs.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: README pages introduce capability without becoming a manual

The template README now includes a `## Capabilities` section after installation. New modules can use this section for concise examples that explain the module's value and first mental model.

## Changed: Detailed documentation remains generated

The README still points users to the `psmodule.io/<ModuleName>` URL pattern and PowerShell help for command-level details.

## Technical Details

- Updates `README.md` only.
- Keeps `{{ NAME }}` and `{{ DESCRIPTION }}` as intentional template tokens.
- Aligns with the repository defaults documented in `PSModule/docs`.
