### PR TITLE
⚙️ [Maintenance]: Lock Pester test dependency to the 6.x major version

### DIFF
--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.999.999'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,6 @@
-﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.999.999'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',
     Justification = 'Required for Pester tests'
 )]


### PR DESCRIPTION
Modules scaffolded from this template now inherit a Pester **6.x** major-version requirement in their test file, so every new module starts aligned with the rest of the ecosystem.

## Changed: the module test template requires Pester 6.x

`tests/PSModuleTest.Tests.ps1` now starts with:

```powershell
#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
```

Any Pester `6.x` satisfies it; adopting a new major stays a deliberate change.

## Technical Details

- Adds a `#Requires -Modules` statement to the template's test file. Module-identity (`GUID`) pinning is intentionally omitted — a separate supply-chain control, not part of the lock-to-major risk appetite.
- The install side is locked to the same major in PSModule/Invoke-Pester#70. Part of the dependency-management epic PSModule/Process-PSModule#356.
