### PR TITLE
⚙️ [Maintenance]: Adopt Process-PSModule v6.1.1 and showcase test data (secret + variable) in tests

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,3 +30,14 @@ jobs:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@ea19a3eb1293246d1b00e4faae1544442c3be0ec # v6.1.1
     secrets:
       APIKEY: ${{ secrets.APIKEY }}
+      # Showcase: send data down to the module tests (see tests/Environment.Tests.ps1).
+      # TestData is a single-line JSON object with optional "secrets" (masked in logs) and
+      # "variables" (not masked) maps. Every entry is exposed to the module test jobs as
+      # $env:<name>. Reference a repository secret with the direct "${{ secrets.NAME }}"
+      # form (single-line values, no quotes or backslashes) and a repository variable with
+      # ${{ toJSON(vars.NAME) }} so any characters are encoded safely. The folded ">-" scalar
+      # keeps the whole value on one line so GitHub registers a single log mask. Omit
+      # TestData entirely when your tests need no data.
+      TestData: >-
+        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
+        "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,6 +27,6 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@60bdf8a5a4c92c53fcf2a8d23f7d5f5c93e6864e # v5.4.3
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@ea19a3eb1293246d1b00e4faae1544442c3be0ec # v6.1.1
     secrets:
       APIKEY: ${{ secrets.APIKEY }}

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -1,0 +1,29 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Required for Pester tests'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Required for Pester tests'
+)]
+[CmdletBinding()]
+param()
+
+Describe 'TestData is exposed to the module tests' {
+    # Showcase for the Process-PSModule 'TestData' feature. The calling workflow
+    # (.github/workflows/Process-PSModule.yml) passes a repository secret and a repository
+    # variable through a single TestData object, and the framework exposes each of them to
+    # the module tests as an environment variable. To see these run, add a repository secret
+    # named 'TEST_SECRET' and a repository variable named 'TEST_VARIABLE'. When they are not
+    # configured the tests skip, so a fresh repository created from this template stays green.
+
+    It 'Exposes the secret from the "secrets" map as $env:TEST_SECRET' -Skip:([string]::IsNullOrEmpty($env:TEST_SECRET)) {
+        # Values in the "secrets" map are masked in the workflow logs.
+        $env:TEST_SECRET | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exposes the variable from the "variables" map as $env:TEST_VARIABLE' -Skip:([string]::IsNullOrEmpty($env:TEST_VARIABLE)) {
+        # Values in the "variables" map are not masked.
+        $env:TEST_VARIABLE | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
Updates the shared `Process-PSModule` reusable workflow from `v5.4.3` to the latest `v6.1.1`, and adds a worked example of the v6 `TestData` feature so module authors can see how to pass a secret and a variable down to their tests.

## Changed: Process-PSModule bumped to v6.1.1

The template now consumes `Process-PSModule` `v6.1.1` (was `v5.4.3`). The v6 major release replaced the fixed `TEST_*` workflow secret inputs with a single `TestData` object; the template did not use any `TEST_*` secrets, and the `.github/PSModule.yml` settings keys used here (`Test.CodeCoverage.PercentTarget`, `Linter.env`) remain valid in v6.

## New: Showcase for passing test data to the module tests

`.github/workflows/Process-PSModule.yml` now passes a `TestData` object with one secret and one variable:

```yaml
TestData: >-
  { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
  "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }
```

- Entries in `secrets` are masked in the logs; entries in `variables` are not.
- Both are exposed to the module test jobs as `$env:<name>`.

`tests/Environment.Tests.ps1` consumes them and asserts they arrive. The tests **skip** when the values are absent, so a fresh repository created from this template stays green (GitHub does not copy repository secrets/variables to template instances).

## Technical Details

- `.github/workflows/Process-PSModule.yml`: pin `workflow.yml@60bdf8a…` (`v5.4.3`) → `@ea19a3eb1293246d1b00e4faae1544442c3be0ec` (`v6.1.1`); add the commented `TestData` block.
- `tests/Environment.Tests.ps1`: new, mirrors the sibling test-file header; `-Skip` when the env var is empty; PSScriptAnalyzer-clean against `.github/linters/.powershell-psscriptanalyzer.psd1`.
- Non-sensitive demo repository secret `TEST_SECRET` and variable `TEST_VARIABLE` were added to this repo so its own CI exercises the showcase; both are safe placeholder values.
- Validated locally with Pester: 2 passed with the env vars set, 2 skipped without. PR checks (pull_request event) are green.
- Supersedes Dependabot PR #23 (bump to `5.5.7`), which Dependabot will close automatically once this merges to a higher version.

### Known limitation on v6.1.1

On v6.1.0/v6.1.1 the `Plan` job fails on `schedule` and `workflow_dispatch` events (its `Resolve-Version` step requires a `pull_request` event), so the template's scheduled/manual runs will fail until fixed upstream. `pull_request` runs — the primary development path — are unaffected. Tracked in PSModule/Process-PSModule#373.
