### PR TITLE
⚙️ [Maintenance]: Showcase both docs section landing-page conventions (index.md + folder-named)

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@ea19a3eb1293246d1b00e4faae1544442c3be0ec # v6.1.1
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKEY: ${{ secrets.APIKEY }}
       # Showcase: send data down to the module tests (see tests/Environment.Tests.ps1).

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,14 +30,6 @@ jobs:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKEY: ${{ secrets.APIKEY }}
-      # Showcase: send data down to the module tests (see tests/Environment.Tests.ps1).
-      # TestData is a single-line JSON object with optional "secrets" (masked in logs) and
-      # "variables" (not masked) maps. Every entry is exposed to the module test jobs as
-      # $env:<name>. Reference a repository secret with the direct "${{ secrets.NAME }}"
-      # form (single-line values, no quotes or backslashes) and a repository variable with
-      # ${{ toJSON(vars.NAME) }} so any characters are encoded safely. The folded ">-" scalar
-      # keeps the whole value on one line so GitHub registers a single log mask. Omit
-      # TestData entirely when your tests need no data.
       TestData: >-
         { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
         "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }

--- a/src/functions/public/IndexSection/Get-IndexSectionTest.ps1
+++ b/src/functions/public/IndexSection/Get-IndexSectionTest.ps1
@@ -1,0 +1,21 @@
+﻿function Get-IndexSectionTest {
+    <#
+        .SYNOPSIS
+        Performs tests on a module.
+
+        .DESCRIPTION
+        Performs tests on a module.
+
+        .EXAMPLE
+        Get-IndexSectionTest -Name 'World'
+
+        "Hello, World!"
+    #>
+    [CmdletBinding()]
+    param (
+        # Name of the person to greet.
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+    Write-Output "Hello, $Name!"
+}

--- a/src/functions/public/IndexSection/index.md
+++ b/src/functions/public/IndexSection/index.md
@@ -1,0 +1,5 @@
+# Index Section
+
+This section's landing page is provided by an `index.md` file.
+
+When Process-PSModule builds the documentation site, this page becomes the landing page for the **Index Section** group in the navigation on GitHub Pages.

--- a/src/functions/public/NamedSection/Get-NamedSectionTest.ps1
+++ b/src/functions/public/NamedSection/Get-NamedSectionTest.ps1
@@ -1,0 +1,21 @@
+﻿function Get-NamedSectionTest {
+    <#
+        .SYNOPSIS
+        Performs tests on a module.
+
+        .DESCRIPTION
+        Performs tests on a module.
+
+        .EXAMPLE
+        Get-NamedSectionTest -Name 'World'
+
+        "Hello, World!"
+    #>
+    [CmdletBinding()]
+    param (
+        # Name of the person to greet.
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+    Write-Output "Hello, $Name!"
+}

--- a/src/functions/public/NamedSection/NamedSection.md
+++ b/src/functions/public/NamedSection/NamedSection.md
@@ -1,0 +1,5 @@
+# Named Section
+
+This section's landing page is provided by a file named after its folder (`NamedSection.md`).
+
+When Process-PSModule builds the documentation site, this page becomes the landing page for the **Named Section** group in the navigation on GitHub Pages.

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -22,4 +22,10 @@ Describe 'Module' {
     It 'Function: Test-PSModuleTest' {
         Test-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
+    It 'Function: Get-IndexSectionTest' {
+        Get-IndexSectionTest -Name 'World' | Should -Be 'Hello, World!'
+    }
+    It 'Function: Get-NamedSectionTest' {
+        Get-NamedSectionTest -Name 'World' | Should -Be 'Hello, World!'
+    }
 }


### PR DESCRIPTION
Two example command groups demonstrate both supported ways to give a command group its documentation section landing page. `IndexSection` provides its landing page as `index.md`; `NamedSection` provides its landing page as a file named after the folder (`NamedSection.md`). Document-PSModule renders either overview page as the group's section landing page, so each group appears at `Functions/<Group>/` in the navigation of the published GitHub Pages site.

- Demonstrates PSModule/Process-PSModule#372 (group overview pages become section landing pages)
- Adopts PSModule/Process-PSModule#377 (caller-provided TestData reaches module tests in consumer repositories)

## New: Two command groups showcasing both landing-page conventions

- `IndexSection/` — landing page from `index.md`, with `Get-IndexSectionTest`.
- `NamedSection/` — landing page from the folder-named `NamedSection.md`, with `Get-NamedSectionTest`.

Each renders as its group's section landing page (`Functions/IndexSection/` and `Functions/NamedSection/`) in the docs navigation.

## Technical Details

- Adds `src/functions/public/IndexSection/{index.md, Get-IndexSectionTest.ps1}` and `src/functions/public/NamedSection/{NamedSection.md, Get-NamedSectionTest.ps1}`; both functions mirror the existing `*-PSModuleTest` shape and return `Hello, <Name>!`.
- Adds `It` blocks for `Get-IndexSectionTest` and `Get-NamedSectionTest` in `tests/PSModuleTest.Tests.ps1`.
- Generated docs place each group overview at `<Group>/index.md`; the rendered site exposes `Functions/IndexSection/index.html` and `Functions/NamedSection/index.html`.
- Bumps the Process-PSModule pin (`v6.1.1` → `v6.1.2`) to adopt the fix that exposes caller-provided `TestData` to the module test jobs, keeping the module test matrix green.
