### PR TITLE
fix: use blank-line description format for .INPUTS and .OUTPUTS

### DIFF
--- a/src/functions/public/Get-PSModuleTest.ps1
+++ b/src/functions/public/Get-PSModuleTest.ps1
@@ -15,8 +15,12 @@ function Get-PSModuleTest {
         .INPUTS
         None
 
+        You cannot pipe objects to this function.
+
         .OUTPUTS
         System.String
+
+        A greeting string for the given name.
     #>
     [OutputType([string])]
     [CmdletBinding()]


### PR DESCRIPTION
## What

Updates the scaffold function to use the blank-line description format for `.INPUTS` and `.OUTPUTS` comment-based help:

```powershell
.INPUTS
None

You cannot pipe objects to this function.

.OUTPUTS
System.String

A greeting string for the given name.
```

## Why

The type-name-only format works but gives callers no useful context. Descriptions are required — they should say what is actually piped in or returned, not just repeat the type name.

This PR is also a **CI verification**: confirming that the blank-line format (type → blank line → description paragraph) passes PlatyPS + markdownlint in Build-Docs. Previous attempts failed with:
- Single-line `System.String. Description.` → MD026 (trailing `.` in heading)
- 4-space-indented description → MD046 (indented code block)

The blank-line format should produce a clean `### type` heading with the description as body text below — no linting violations.

## Informs

- [MSXOrg/docs#69](https://github.com/MSXOrg/docs/pull/69) — if CI passes here, #69 should be closed and the docs updated to require descriptions in this format.