### PR TITLE
Remove navigation.indexes from Zensical features

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -11,7 +11,6 @@ favicon = "Assets/icon.png"
 features = [
     "navigation.instant",
     "navigation.instant.progress",
-    "navigation.indexes",
     "navigation.top",
     "navigation.tracking",
     "navigation.expand",


### PR DESCRIPTION
## Summary

Removes `navigation.indexes` from the Zensical theme features in `.github/zensical.toml`.

## What changed

- Dropped `navigation.indexes` from the `[project.theme]` features list

## Why

`navigation.indexes` creates clickable section index headers in the left-side navigation menu of the generated Zensical docs site. Removing it eliminates that visual header, resulting in a cleaner left-side navigation without the section-level heading element.