### PR TITLE
🩹 [Patch]: New module repositories ship the required community and governance files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+See [`AGENTS.md`](../AGENTS.md) for all onboarding and guidance pointers for this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,0 @@
-# Copilot Instructions
-
-See [`AGENTS.md`](../AGENTS.md) for all onboarding and guidance pointers for this repository.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+This description becomes the release note. Write it for users of the module, not for reviewers.
+
+Title: <Icon> [<Type>]: <User-facing outcome>
+  🌟 [Major] · 🚀 [Feature] · 🩹 [Patch] · 🪲 [Fix] · 📖 [Docs] · ⚙️ [Maintenance]
+
+Apply the matching label: Major, Minor, Patch, or NoRelease.
+Full format: https://msxorg.github.io/docs/Ways-of-Working/PR-Format/
+
+Delete the comments and any unused section before marking the pull request ready.
+-->
+
+<!-- One paragraph, present tense, describing what changes for the user. -->
+
+## New: <capability>
+
+<!--
+What the user can now do, what they need to do differently, and an example.
+Use the section headers that fit the change and delete the rest:
+  ## Breaking Changes   - what stopped working or changed incompatibly (Major only)
+  ## New: <capability>  - new things the user can do
+  ## Changed: <behavior> - existing behavior that now works differently
+  ## Fixed: <problem>   - problems now resolved
+-->
+
+## Technical Details
+
+<!-- For reviewers: files touched, design decisions, migration notes. Delete this section if there is nothing noteworthy. -->
+
+<details>
+<summary>Related issues</summary>
+
+<!-- Use fully qualified references, for example: Fixes PSModule/Repo#123 -->
+
+</details>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[psmodule@psmodule.io](mailto:psmodule@psmodule.io).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For step-by-step instructions, see the [template quickstart](https://psmodule.gi
 
 ## After creating a repository from this template
 
-1. Replace the `{{ NAME }}` and `{{ DESCRIPTION }}` placeholders throughout the repository.
+1. Replace the `{{ NAME }}` placeholder with your module name throughout the repository.
 2. Replace the starter function, test, and example with your module's first real command.
 3. Set the repository description and custom properties on GitHub.
 4. Confirm `.github/PSModule.yml` only overrides defaults when your module needs different behavior.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version of this module is supported.
+Fixes are shipped as a new release rather than backported to older versions, so upgrade before reporting an issue.
+
+## Reporting a vulnerability
+
+Do not report security issues through public issues, pull requests, or discussions.
+A public report puts other users at risk before a fix exists.
+
+Report privately instead:
+
+1. Open the repository's **Security** tab and use **Report a vulnerability** to file a private security advisory.
+2. If private reporting is unavailable, send an email to [psmodule@psmodule.io](mailto:psmodule@psmodule.io).
+
+Include what the problem is, which module version is affected, and how to reproduce it.
+Reports are handled privately until a fixed version is published.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## This module
+
+Use the issues on this repository for bugs, feature requests, and questions about the module.
+Search the existing issues first, the answer may already be there.
+
+For anything that does not belong in a public issue, send an email to [psmodule@psmodule.io](mailto:psmodule@psmodule.io).
+
+Do not use issues to report security vulnerabilities. Follow [`SECURITY.md`](SECURITY.md) instead.
+
+## PowerShell Gallery
+
+Problems with the PowerShell Gallery itself, such as package listings, downloads, or accounts, belong with the Gallery maintainers:
+
+- [PowerShell/PowerShellGallery issues](https://github.com/PowerShell/PowerShellGallery/issues)
+- [cgadmin@microsoft.com](mailto:cgadmin@microsoft.com)
+
+## Fixing it yourself
+
+Contributions are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) to get started.


### PR DESCRIPTION
Repositories created from this template now ship the community and governance files that the PSModule [Repository Defaults](https://psmodule.github.io/docs/Modules/Repository-Defaults/) standard requires, so a new module repository is compliant on its first commit instead of starting with a manual cleanup task. The template previously relied on the organization `.github` fallback, which is only surfaced in GitHub's web UI — agents, linters, and local tooling never see it.

## New: Security policy

`SECURITY.md` states that only the latest released version is supported and routes vulnerability reports to a private security advisory, with `psmodule@psmodule.io` as the fallback. It is deliberately worded so a reporter never opens a public issue for a vulnerability.

## New: Support routing

`SUPPORT.md` tells users where to go: repository issues for the module, `psmodule@psmodule.io` for anything that does not belong in public, and the PowerShell Gallery maintainers for Gallery problems. It points at `SECURITY.md` for vulnerabilities and `CONTRIBUTING.md` for people who want to fix it themselves.

## New: Code of conduct

`CODE_OF_CONDUCT.md` is Contributor Covenant 2.1, matching the organization-level file, with `psmodule@psmodule.io` filled in as the enforcement contact instead of the `[INSERT CONTACT METHOD]` placeholder the org copy still carries.

## New: Pull request template

`.github/pull_request_template.md` prompts for the PR Manager format from [PR Format](https://msxorg.github.io/docs/Ways-of-Working/PR-Format/): the title pattern with its icon and change type, a user-facing summary, the `New`/`Changed`/`Fixed`/`Breaking Changes` sections, a technical section for reviewers, and a collapsible related-issues block. All guidance is in HTML comments so it disappears from the rendered description and never leaks into generated release notes.

## Changed: Setup instructions name a placeholder that exists

The README told new module authors to replace `{{ NAME }}` and `{{ DESCRIPTION }}`, but the template only ships `{{ NAME }}` (in `examples/General.ps1`). The step now names only the placeholder that is actually there.

## Technical Details

- `.github/copilot-instructions.md` was added and then removed again during this work. Repository Defaults still lists it as required, but `AGENTS.md` at the repository root is the agent entry point and is read natively by the runtimes, so a Copilot-only pointer file is duplication that drifts. The stale table entry is tracked in PSModule/Process-PSModule#507.
- **Custo:** none of these files are distributed by [`MSXOrg/Custo`](https://github.com/MSXOrg/Custo) today. Custo currently contains only a README and a LICENSE, and its bootstrap work is still in draft. Its predecessor, `PSModule/Distributor`, manages `CODEOWNERS`, `LICENSE`, linter settings, `PSModule.yml`, `dependabot.yml`, `.gitattributes`, `.gitignore`, instructions, hooks, and prompts for module repositories — it does not manage any of the files in this pull request. The template is therefore the right home for them right now. When Custo starts distributing community files, these copies become the seed for the managed source and further wording changes belong in Custo, not here.
- Rest of the template was checked against the Repository Defaults required-files and layout tables. Everything else required is present, and `@PSModule/module-maintainers` in `CODEOWNERS` resolves to a real team.
- Two remaining mismatches are docs problems rather than template problems and are covered by PSModule/Process-PSModule#507, both confirmed against a 24-repository survey of the organization:
  - The layout table names `.github/workflows/workflow.yml`, but all 24 surveyed module repositories use `Process-PSModule.yml` and none has a `workflow.yml`. `workflow.yml` is the *called* reusable workflow inside `PSModule/Process-PSModule`, not the caller.
  - The supply-chain section publishes a fixed configuration block containing `package-ecosystem: "powershell"`, which does not exist in Dependabot — `dependabot-core@dc2e4422d` ships 33 ecosystems and none of them cover PowerShell or the PowerShell Gallery. Adding it breaks the entire Dependabot configuration, including the `github-actions` entry. All 24 surveyed repositories configure `github-actions`, and only `Sodium` adds a second one (`nuget`, for its .NET assembly). The issue asks for the guidance to be restated as a rule — configure `github-actions` plus whichever additional ecosystems apply and are supported by the current version of Dependabot — instead of a copy-paste block that goes stale.

<details>
<summary>Related issues</summary>

- Fixes PSModule/Template-PSModule#36
- PSModule/Process-PSModule#507

</details>
