### PR TITLE
⚙️ [Maintenance]: Markdown pages can carry both a front matter title and a body heading

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -14,6 +14,8 @@ MD007:
 MD013:
   line_length: 808 # Line length
 MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
+MD025:
+  front_matter_title: '' # Allow a body H1 alongside the front matter title
 MD026:
   punctuation: '.,;:!。，；:' # List of not allowed
 MD029: false # Ordered list item prefix


### PR DESCRIPTION
Markdown pages in repositories generated from this template can now carry both a front matter `title:` and a body `# Heading` without the linter objecting. MkDocs keeps using the front matter title for navigation and the page title, and the body heading keeps rendering on github.com, where front matter is shown as a table rather than a title.

## Fixed: A front matter title is no longer counted as a second top-level heading

The markdown linter shipped with the template applied markdownlint's default `front_matter_title` pattern, so a front matter `title:` was treated as the document's top-level heading. Any page that also opened with `# Heading` was reported as `MD025/single-title/single-h1 Multiple top-level headings in the same document`, and the author was pushed toward dropping one of the two — losing either correct site navigation or a readable page on GitHub.

Nothing needs to change in your repository. Repositories generated from the template inherit the fix, and existing repositories pick it up the next time they take the template's linter configuration.

MD025 still does its job: a page with two body `# Heading` lines is reported exactly as before.

---
<details>
<summary>Technical details</summary>

`.github/linters/.markdown-lint.yml` gains one block in the "Rules by id" section, in numeric order between `MD024` and `MD026`:

```yaml
MD025:
  front_matter_title: '' # Allow a body H1 alongside the front matter title
```

- **Empty pattern rather than `MD025: false`.** `frontMatterHasTitle()` in markdownlint treats a defined-but-falsy pattern as "ignore front matter" while leaving the rest of the rule active, so a genuinely duplicated body `# Heading` is still reported. Disabling the rule outright would stop catching that too, which is a real defect rather than a formatting preference.
- **Converges with MSXOrg/docs**, which carries `front_matter_title: ""` with the same comment in its copy of this file. Single quotes are used here to match the one existing quoted value in this file (`punctuation: '.,;:!。，；:'`); `''` and `""` are the same empty YAML scalar, and markdownlint sees an identical value either way.
- **No other rule was touched.** The wider drift from MSXOrg/docs — `MD013` line length (808 vs 3000), `MD041`, `MD051`, `MD060` — is visible but deliberately out of scope.
- `PSModule/Markdown` carries a byte-identical copy of this file and hit this exact problem in PSModule/Markdown#33, where `title:` had to be stripped from three documentation files to get a green lint run. Fixing the template is what stops that repeating in every module repository.

**Verification.** Throwaway fixtures outside the repository, ephemeral `npx`, nothing added to the repo. Run against both `markdownlint-cli@0.45.0` (the CLI super-linter drives) and `markdownlint-cli2@0.23.2` (markdownlint v0.41.1); the two agree on every case.

| Case | Config | Result |
| --- | --- | --- |
| Front matter `title:` + body `# Heading` | before | `MD025` reported at the body heading — reproduces the bug |
| Front matter `title:` + body `# Heading` | after | Clean, exit 0 |
| Two body `# Heading` lines | after | `MD025` still reported at the second heading |
| The repository's own 8 Markdown files | after | Clean, exit 0 |

Implementation plan progress: both plan sections in PSModule/Template-PSModule#38 — configuration and verification — are complete. Nothing deferred.

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `.github/linters/**` (linter configuration) | MSXOrg Coding Standards | Repository Defaults | Aligned |

Issue convergence sweep: the scope was every open issue in `PSModule/Template-PSModule`. #38 is the only one, and it is the closing issue for this pull request.

</details>

<details>
<summary>Relevant issues (or links)</summary>

- Fixes PSModule/Template-PSModule#38

</details>