### PR TITLE
🪲 [Fix]: Keep VS Code snippet files out of the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/*.code-snippets
 *.code-workspace
 
 # Local History for Visual Studio Code


### PR DESCRIPTION
Repositories created from this template can once again commit VS Code workspace snippets.

## Fixed: `.vscode/*.code-snippets` is no longer ignored

The `.vscode` block in `.gitignore` ignores the whole folder and then un-ignores the files a team is expected to share. The canonical [`github/gitignore` VS Code template](https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore) un-ignores `settings.json`, `tasks.json`, `launch.json`, `extensions.json`, **and** `*.code-snippets`. This template dropped the last one, so a workspace snippet file added on purpose stayed invisible to git in every repository generated from the template.

Noticed while aligning [`PSModule/PSSemVer`](https://github.com/PSModule/PSSemVer/pull/46) to the repository standard: PSSemVer still carries the line, so syncing it to the template would have been a regression.

## Technical Details

- `.gitignore`: adds `!.vscode/*.code-snippets` after `!.vscode/extensions.json`, matching the canonical ordering.

<details>
<summary>Related issues</summary>

</details>