### PR TITLE
📖 [Docs]: Documentation links in the template resolve again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Regarding repo structure, module source code and how the Process-PSModule workfl
 For PSModule-specific build, layout, and process guidance:
 
 - [Template quickstart](https://psmodule.github.io/docs/Modules/Process-PSModule/template-quickstart/) — how to create a new module from this template.
-- [Repository defaults](https://psmodule.github.io/docs/Modules/Repository-Defaults/) — the expected repository layout and required files.
+- [Repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) — the expected repository layout and required files.
 - [Module anatomy](https://psmodule.github.io/docs/Modules/Process-PSModule/module-anatomy/) — source layout and framework conventions.
 - [Build, test, pack, publish](https://psmodule.github.io/docs/Modules/Process-PSModule/build-test-pack-publish/) — the CI/CD pipeline.
 - [Standards](https://psmodule.github.io/docs/Modules/Standards/) — PowerShell module coding standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,11 @@ If you find a problem or improvement, fix if small; otherwise open an issue.
 Regarding repo structure, module source code and how the Process-PSModule workflow works.
 For PSModule-specific build, layout, and process guidance:
 
-- [Template quickstart](https://psmodule.github.io/docs/Modules/Process-PSModule/template-quickstart/) — how to create a new module from this template.
+- [Template quickstart](https://psmodule.io/docs/Modules/Process-PSModule/template-quickstart/) — how to create a new module from this template.
 - [Repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) — the expected repository layout and required files.
-- [Module anatomy](https://psmodule.github.io/docs/Modules/Process-PSModule/module-anatomy/) — source layout and framework conventions.
-- [Build, test, pack, publish](https://psmodule.github.io/docs/Modules/Process-PSModule/build-test-pack-publish/) — the CI/CD pipeline.
-- [Standards](https://psmodule.github.io/docs/Modules/Standards/) — PowerShell module coding standards.
+- [Module anatomy](https://psmodule.io/docs/Modules/Process-PSModule/module-anatomy/) — source layout and framework conventions.
+- [Build, test, pack, publish](https://psmodule.io/docs/Modules/Process-PSModule/build-test-pack-publish/) — the CI/CD pipeline.
+- [Standards](https://psmodule.io/docs/Modules/Standards/) — PowerShell module coding standards.
 - [PSModule/memory](https://github.com/PSModule/memory) — durable cross-session agent working memory for the PSModule organization.
 
 ## Org-wide guidance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ For PR format guidance, see [PR Format](https://msxorg.github.io/docs/Ways-of-Wo
 ## Issues
 
 Use GitHub Issues to report bugs, request features, or propose improvements.
-Follow the [issue format](https://msxorg.github.io/docs/Ways-of-Working/Issue-Format/) guidance.
+Follow the [issue format](https://msxorg.github.io/docs/Ways-of-Working/Issues/Process/Format/) guidance.
 
 ## Code standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Read [`AGENTS.md`](AGENTS.md) first for the full guidance chain and documentatio
 ## Before you start
 
 1. Read [`README.md`](README.md) to understand what the module does.
-2. Familiarise yourself with the [repository defaults](https://psmodule.github.io/docs/Modules/Repository-Defaults/) that this repository must satisfy.
+2. Familiarise yourself with the [repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) that this repository must satisfy.
 3. Check the open issues and pull requests to avoid duplicate work.
 
 ## Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Follow the [issue format](https://msxorg.github.io/docs/Ways-of-Working/Issue-Fo
 
 ## Code standards
 
-PowerShell in this module follows the [PSModule Standards](https://psmodule.github.io/docs/Modules/Standards/) and the
+PowerShell in this module follows the [PSModule Standards](https://psmodule.io/docs/Modules/Standards/) and the
 [MSXOrg Coding Standards](https://msxorg.github.io/docs/Coding-Standards/).
 
 ## Questions

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For step-by-step instructions, see the [template quickstart](https://psmodule.gi
 4. Confirm `.github/PSModule.yml` only overrides defaults when your module needs different behavior.
 5. Open a draft pull request and run the full CI pipeline.
 
-See [repository defaults](https://psmodule.github.io/docs/Modules/Repository-Defaults/) for the full checklist.
+See [repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) for the full checklist.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The canonical starting template for new PowerShell modules in the PSModule organ
 Use this template when creating a new PowerShell module repository.
 It provides the CI/CD framework wiring, required community files, and starter layout that every PSModule module repository needs.
 
-For step-by-step instructions, see the [template quickstart](https://psmodule.github.io/docs/Modules/Process-PSModule/template-quickstart/).
+For step-by-step instructions, see the [template quickstart](https://psmodule.io/docs/Modules/Process-PSModule/template-quickstart/).
 
 ## After creating a repository from this template
 


### PR DESCRIPTION
Every documentation link in this template now resolves. Three links in `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` pointed at a PSModule docs page that has been renamed, and a fourth pointed at an MSX page that moved — so a maintainer or agent following the guidance chain from a new module repository landed on a 404 instead of the page they were sent to.

## Fixed: the repository standard link resolves

The "repository defaults" link now points at [Repository standard](https://psmodule.io/docs/Modules/Repository-Standard/), which is where that page lives after it was renamed in [PSModule/docs#96](https://github.com/PSModule/docs/pull/96). The link text follows the page's new name, so the reference reads the same way the destination is titled.

This matters beyond this repository: `README.md`, `AGENTS.md`, and `CONTRIBUTING.md` are copied into every module repository created from this template, so the broken link was being propagated with each new module.

## Fixed: the issue format link resolves

The "issue format" link pointed at `Ways-of-Working/Issue-Format/`, which no longer exists. It now points at [Issues / Process / Format](https://msxorg.github.io/docs/Ways-of-Working/Issues/Process/Format/), the page that replaced it.

## Changed: PSModule documentation links use the canonical host

PSModule documentation links now use `psmodule.io` directly instead of `psmodule.github.io`, which only reaches the site through a redirect. Nothing changes about where a reader ends up — the links simply state the canonical host, which is what `site_url` in `PSModule/docs` declares.

---
<details>
<summary>Technical details</summary>

**How the broken links were found.** [PSModule/Process-PSModule#486](https://github.com/PSModule/Process-PSModule/issues/486) established that the documentation site had not been republished since 2026-07-18, which is why the renamed page still appeared to work: the old URL kept serving a stale build. Once [PSModule/docs#107](https://github.com/PSModule/docs/pull/107) restores publishing, the rename goes live and the old path starts returning 404. The referrer set was enumerated with `gh search code "Repository-Defaults" --owner PSModule`, which found eight files across four repositories; this pull request covers the three in this repository, and the rest are tracked on [PSModule/Process-PSModule#487](https://github.com/PSModule/Process-PSModule/issues/487).

**Why the links were fixed rather than a redirect added.** Recorded on [PSModule/Process-PSModule#487](https://github.com/PSModule/Process-PSModule/issues/487). In short: Zensical has no redirect support — [`zensical/backlog#23`](https://github.com/zensical/backlog/issues/23) is open — so a redirect would have to be a hand-written stub page that is built, search-indexed, excluded from navigation, and maintained indefinitely. The referrers are enumerable and in-organization, so correcting them is the smaller change.

**Host handling, and why only the PSModule links changed.** `psmodule.github.io` returns `301` to `psmodule.io`, and `PSModule/docs` declares `site_url = "https://psmodule.io/docs/"`, so `psmodule.io` is unambiguously canonical and the links now say so. The MSX links were deliberately left on `msxorg.github.io`: that host also redirects, to `msx.no`, but `MSXOrg/docs` still declares `site_url = "https://msxorg.github.io/..."`, so which host is canonical there is not settled and this pull request is not the place to decide it. Only the genuinely broken MSX *path* was corrected.

**Verification.** Every documentation URL in the changed files was requested; all return `200`.

| URL | Status |
| --- | --- |
| `https://psmodule.io/docs/Modules/Process-PSModule/template-quickstart/` | 200 |
| `https://psmodule.io/docs/Modules/Process-PSModule/module-anatomy/` | 200 |
| `https://psmodule.io/docs/Modules/Process-PSModule/build-test-pack-publish/` | 200 |
| `https://psmodule.io/docs/Modules/Standards/` | 200 |
| `https://msxorg.github.io/docs/Ways-of-Working/Issues/Process/Format/` | 200 |
| `https://psmodule.io/docs/Modules/Repository-Standard/` | 404 until [PSModule/docs#107](https://github.com/PSModule/docs/pull/107) merges, 200 after |

The last row is the one dependency: this pull request should merge after [PSModule/docs#107](https://github.com/PSModule/docs/pull/107) restores publishing, or the link it introduces is briefly the broken one.

**Standards and framework alignment.**

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `README.md`, `AGENTS.md`, `CONTRIBUTING.md` | [Markdown](https://msxorg.github.io/docs/Coding-Standards/Markdown/), [Documentation](https://msxorg.github.io/docs/Coding-Standards/Documentation/) — link-only changes, structure untouched | [Repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) — the three files remain present and unchanged in purpose | Aligned |

**Issue convergence sweep.** Scope: open issues in this repository and in `PSModule/docs` concerning the template's community files or documentation links. Nothing in this repository is fully satisfied by this diff. [PSModule/Process-PSModule#487](https://github.com/PSModule/Process-PSModule/issues/487) is only partially satisfied — the already-propagated copies in `PSSemVer` and `Lovdata` remain — so it is linked without a closing keyword. [PSModule/Process-PSModule#478](https://github.com/PSModule/Process-PSModule/issues/478), on distributing these files, is untouched and remains the durable answer to this class of drift.

</details>

<details>
<summary>Relevant issues (or links)</summary>

- PSModule/Process-PSModule#487 — the link rot this pull request covers the template's share of
- PSModule/docs#107 — restores publishing, and must merge first
- PSModule/docs#96 — the rename
- PSModule/Process-PSModule#478 — distributing these files, the durable fix for the drift

</details>
