### PR TITLE
🩹 [Patch]: Local test runs no longer leave a coverage report to commit by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ outputs/*
 bin/
 obj/
 libs/
+
+# Pester code coverage report written to the working directory by a local test run
+coverage.xml


### PR DESCRIPTION
A local test run no longer leaves an untracked file that gets committed by accident. Running Pester with code coverage writes `coverage.xml` into the working directory, and nothing ignored it, so the report showed up in `git status` and was easy to stage without noticing.

## Fixed: the Pester coverage report stays out of commits

`.gitignore` now ignores `coverage.xml`. Contributors running the test suite locally get a clean `git status` afterwards, and the report cannot be committed by a `git add -A`.

Nothing about how coverage is produced or published changes. CI still generates and uploads the report as a build artifact; this only stops the local copy from being tracked.

---
<details>
<summary>Technical details</summary>

**Found in the wild, not hypothetically.** [PSModule/CasingStyle#22](https://github.com/PSModule/CasingStyle/pull/22) adds a 126-line JaCoCo `coverage.xml` at the repository root alongside its intended changes — the signature of a local Pester run followed by `git add -A`.

**It is accidental, not a convention.** `gh search code --owner PSModule --filename coverage.xml` returns nothing across all 96 repositories in the organization, so no repository tracks one deliberately. CasingStyle would have been the first.

**Why the file lands at the root.** Pester writes its coverage report to the working directory by default, which is the repository root for a local run. The existing `outputs/*` rule covers the framework's own build output, but the coverage report is not written there.

**Why this belongs in the template — and what it does not do.** The template is the source every new module repository is created from, so fixing it here is what stops the gap being reproduced. All 58 repositories carrying `Type: Module` have the same gap today, and this pull request does **not** reach any of them.

An earlier revision of this description claimed it would, via the `SubscribeTo` custom property. That claim was wrong and is retracted. Checked afterwards, and the correction is worth stating plainly because it changes what this pull request is worth:

| Check | Result |
| --- | --- |
| Module repositories with `SubscribeTo` set | **1 of 58** (`PSModule/GitHub`, value `Custom Instructions, License, Prompts`) |
| Module repositories subscribed to `gitignore` | **0 of 58** |
| The only consumer of `SubscribeTo`, anywhere | `PSModule/Distributor/scripts/Sync-Files.ps1` — its workflow is `disabled_inactivity`, last ran 2026-06-05, and succeeded on only 3 of 76 runs ever |
| Contents of [`MSXOrg/Custo`](https://github.com/MSXOrg/Custo), the documented successor runtime | `LICENSE` and a two-line `README.md` |

So the opt-in is valid and documented, its only engine has been switched off since June, and the documented successor is a stub. (An earlier revision of this table said no implementation existed — that was a search scoped to the wrong organization, corrected on PSModule/Process-PSModule#488.) This pull request therefore fixes the template only; existing repositories keep the gap until distribution actually runs, which is tracked in PSModule/Process-PSModule#478 and the prerequisite work linked from it. Fixing only one repository would still leave the trap in the template, which is the argument for landing this regardless.

**Scope.** One rule and a comment explaining what writes the file. Deliberately not a wider `.gitignore` review, and deliberately not `*.xml` — module repositories legitimately track XML, and a broad glob would silently ignore files that belong in version control.

**Kept separate from [#42](https://github.com/PSModule/Template-PSModule/pull/42).** That pull request corrects documentation links in the community files. This one changes build hygiene. They share no lines and merge in either order.

**Standards and framework alignment.**

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `.gitignore` | None applicable — no ecosystem standard covers ignore rules | [Repository standard](https://psmodule.io/docs/Modules/Repository-Standard/) — names `.gitignore` as a managed file type, so the template is the correct source. The page describes the distribution runtime in the present tense; that overstatement is reported separately, not resolved here | Aligned |

**Issue convergence sweep.** Scope: open issues in this repository and in `PSModule/docs` concerning repository hygiene or the managed file set. Nothing is fully satisfied by this diff. [PSModule/Process-PSModule#472](https://github.com/PSModule/Process-PSModule/issues/472), on reviewing `.gitattributes` for cross-platform development, is adjacent but concerns a different file and is untouched.

</details>

<details>
<summary>Relevant issues (or links)</summary>

- PSModule/CasingStyle#22 — where the untracked report surfaced
- PSModule/Process-PSModule#478 — distributing the managed file set, which is how this reaches existing repositories

</details>


