### PR TITLE
Upgrade Process-PSModule consumer workflow

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -1,32 +1,37 @@
 name: Process-PSModule
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+ workflow_dispatch:
+ schedule:
+ - cron: '0 0 * * *'
+ push:
+ branches:
+ - main
+ pull_request:
+ branches:
+ - main
+ types:
+ - closed
+ - opened
+ - reopened
+ - synchronize
+ - labeled
+ - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+ group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+ cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
-  pages: write
-  id-token: write
+permissions: {}
 
 jobs:
-  Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@fb1bdb8fefd243292f779d2a856a38db6fe6daf4 # v6.1.13
-    secrets:
-      APIKey: ${{ secrets.APIKEY }}
+ Process-PSModule:
+ permissions:
+ contents: read
+ pages: write
+ id-token: write
+ uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
+ secrets:
+ PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+ GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
+ GitHubAppPrivateKey: ${{ secrets.SHELLY_PRIVATE_KEY }}

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -1,37 +1,37 @@
 name: Process-PSModule
 
 on:
- workflow_dispatch:
- schedule:
- - cron: '0 0 * * *'
- push:
- branches:
- - main
- pull_request:
- branches:
- - main
- types:
- - closed
- - opened
- - reopened
- - synchronize
- - labeled
- - unlabeled
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 concurrency:
- group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
- cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
 
 jobs:
- Process-PSModule:
- permissions:
- contents: read
- pages: write
- id-token: write
- uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
- secrets:
- PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
- GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
- GitHubAppPrivateKey: ${{ secrets.SHELLY_PRIVATE_KEY }}
+  Process-PSModule:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
+    secrets:
+      PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+      GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
+      GitHubAppPrivateKey: ${{ secrets.SHELLY_PRIVATE_KEY }}

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -11,12 +11,8 @@
 [CmdletBinding()]
 param()
 
-BeforeAll {
-    . "$PSScriptRoot\..\src\functions\public\Get-PSModuleTest.ps1"
-}
-
 Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
-        Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
+        Get-PSModuleTest -Name 'World' | Should-Be 'Hello, World!'
     }
 }

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -11,6 +11,10 @@
 [CmdletBinding()]
 param()
 
+BeforeAll {
+    . "$PSScriptRoot\..\src\functions\public\Get-PSModuleTest.ps1"
+}
+
 Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -13,6 +13,6 @@ param()
 
 Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
-        Get-PSModuleTest -Name 'World' | Should-Be 'Hello, World!'
+        Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
 }

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -13,6 +13,6 @@ param()
 
 Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
-        Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
+        Get-PSModuleTest -Name 'World' | Should-Be 'Hello, World!'
     }
 }


### PR DESCRIPTION
## Summary
- replace the consumer Process-PSModule workflow with the v8 template
- add required repository triggers, concurrency, permissions, and secrets
- wire the scaffold Pester test through native Pester v6 setup

## Validation
- `Invoke-Pester -Path tests -Output Detailed` (Pester 6.0.1)