### PR TITLE
⚙️ [Maintenance]: Runtime guidance routes use shared instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-@AGENTS.md


### PR DESCRIPTION
New module repositories route both Claude Code and Copilot runtime guidance to the shared `AGENTS.md` instructions. This keeps all agent guidance centralized without removing support for either runtime.

---
<details>
<summary>Technical details</summary>

- Replaced the root `CLAUDE.md` with a `.claude/CLAUDE.md` route using the required relative `@../AGENTS.md` import.
- Added `.github/copilot-instructions.md` as a thin route to `AGENTS.md` for Copilot surfaces that do not read the root file.
- Standards and framework alignment:

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `CLAUDE.md` and `.claude/CLAUDE.md` (Claude Code guidance) | Natural Language | None (no framework-specific docs) | Aligned |
| `.github/copilot-instructions.md` (Copilot guidance) | Natural Language | None (no framework-specific docs) | Aligned |

- Issue convergence sweep: searched open issues for `Claude`; none matched this change.

</details>

<details>
<summary>Relevant issues (or links)</summary>

### Related work
- No related issue; direct maintenance request.

</details>